### PR TITLE
fix: entitlement of build_code

### DIFF
--- a/exercises/ex1/README.md
+++ b/exercises/ex1/README.md
@@ -9,8 +9,8 @@ In this exercise, we will implement the basic Terraform configuration.
 
 After completing these steps, you will have created the file layout needed for the Terraform configuration.
 
-1. Go to the root directory of this project and create a new directory called `terraform-build`
-1. Navigate into the directory `terraform-build`.
+1. Go to the root directory of this project and create a new directory called `terraform_build`
+1. Navigate into the directory `terraform_build`.
 1. Create the following files inside of the directory:
     - `main.tf` - this file will contain the main Terraform configuration
     - `provider.tf` - this file will contain the provider configuration

--- a/modules/build_code/build_code.tf
+++ b/modules/build_code/build_code.tf
@@ -28,7 +28,6 @@ resource "btp_subaccount_entitlement" "build_code" {
   subaccount_id = var.subaccount_id
   service_name  = "build-code"
   plan_name     = "free"
-  amount        = 1
 }
 # Subscribe
 resource "btp_subaccount_subscription" "build_code" {


### PR DESCRIPTION
- fix entitlement of `build_code`: removed amount parameter that causes an error when executing the entitlement
- Wrong directory name in ex1 for creating solutions
