### PR TITLE
chore: update BTP Terraform providerto 1.14.0

### DIFF
--- a/exercises/ex1/README.md
+++ b/exercises/ex1/README.md
@@ -32,7 +32,7 @@ The basic configuration of the Terraform provider for SAP BTP is available in th
         required_providers {
           btp = {
             source  = "SAP/btp"
-            version = "~> 1.13.0"
+            version = "~> 1.14.0"
           }
         }
       }
@@ -44,7 +44,7 @@ The basic configuration of the Terraform provider for SAP BTP is available in th
       }
       ```
 
-      In accordance to the documentation we instruct Terraform to use the provider in version 1.13.0 . We also added the authentication information as a [variable](https://developer.hashicorp.com/terraform/language/values/variables) to increase flexibility. To make the story complete we need to define the variable.
+      In accordance to the documentation we instruct Terraform to use the provider in version 1.14.0 . We also added the authentication information as a [variable](https://developer.hashicorp.com/terraform/language/values/variables) to increase flexibility. To make the story complete we need to define the variable.
 
 1. Open the file `variables.tf`.
 1. Add the following code to the file and save the changes:

--- a/modules/build_code/build_code.tf
+++ b/modules/build_code/build_code.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.13.0"
+      version = "~> 1.14.0"
     }
   }
 }

--- a/modules/build_process_automation/build_process_automation.tf
+++ b/modules/build_process_automation/build_process_automation.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     btp = {
       source  = "sap/btp"
-      version = "~> 1.13.0"
+      version = "~> 1.14.0"
     }
   }
 }

--- a/solutions/ex1/provider.tf
+++ b/solutions/ex1/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.13.0"
+      version = "~> 1.14.0"
     }
   }
 }

--- a/solutions/ex2/provider.tf
+++ b/solutions/ex2/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.13.0"
+      version = "~> 1.14.0"
     }
   }
 }

--- a/solutions/ex3/provider.tf
+++ b/solutions/ex3/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.13.0"
+      version = "~> 1.14.0"
     }
   }
 }

--- a/solutions/ex4/provider.tf
+++ b/solutions/ex4/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.13.0"
+      version = "~> 1.14.0"
     }
   }
 }


### PR DESCRIPTION
Update Terraform provider version to [1.14.0](https://github.com/SAP/terraform-provider-btp/releases/tag/v1.14.0)
